### PR TITLE
Add Dockerized PocketBase backend with standard + ONCE builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,26 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --only=production && npm cache clean --force
+# Install ALL dependencies — the build (vue-tsc + vite) needs devDependencies.
+# This is the builder stage only; the final nginx image carries no node_modules.
+RUN npm ci && npm cache clean --force
 
 # Copy source code
 COPY . .
+
+# Build-time frontend configuration. Vite inlines VITE_*-prefixed env vars into
+# the static bundle, so the backend URL (and friends) must be set BEFORE the
+# build. `.env` is intentionally excluded from the build context, so pass these
+# as --build-arg for self-hosting, e.g.:
+#   docker build --build-arg VITE_POCKETBASE_URL=https://api.example.com -t sitewise-frontend .
+ARG VITE_POCKETBASE_URL=http://localhost:8090
+ARG VITE_APP_NAME=SiteWise
+ARG VITE_APP_ENV=production
+ARG VITE_TURNSTILE_SITE_KEY=
+ENV VITE_POCKETBASE_URL=$VITE_POCKETBASE_URL \
+    VITE_APP_NAME=$VITE_APP_NAME \
+    VITE_APP_ENV=$VITE_APP_ENV \
+    VITE_TURNSTILE_SITE_KEY=$VITE_TURNSTILE_SITE_KEY
 
 # Build the application
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -130,6 +130,26 @@ npm run dev
 
 🎉 Visit **http://localhost:5173** and you're in.
 
+### Self-host with Docker
+
+Both halves of SiteWise ship as containers — the **PocketBase backend** (bundled
+with the SiteWise hooks, on a pinned release) and the **Vue frontend** (nginx).
+
+```bash
+# Backend (PocketBase) — serves on :8090, data in a named volume
+cd external_services/pocketbase
+TURNSTILE_SECRET_KEY=your-secret docker compose up -d --build
+
+# Frontend (point it at your backend at build time)
+docker build --build-arg VITE_POCKETBASE_URL=https://api.your-domain.com \
+  -t sitewise-frontend .
+docker run -d -p 8080:8080 sitewise-frontend
+```
+
+There's also an **[ONCE](https://once.com/)-compatible** backend image
+(`external_services/pocketbase/Dockerfile.once`) for one-command self-hosting on
+the ONCE app server. Full walkthrough: **[docs/SELF_HOSTING.md](docs/SELF_HOSTING.md)**.
+
 ### Run as a desktop app
 
 ```bash
@@ -226,9 +246,9 @@ graph TB
 | Document | Description |
 |----------|-------------|
 | [👥 **User Guide**](USER_GUIDE.md) | End-user manual |
+| [🐳 **Self-Hosting**](docs/SELF_HOSTING.md) | Deploy the backend + frontend with Docker (incl. ONCE) |
 | [🤝 **Contributing**](CONTRIBUTING.md) | How to contribute to the project |
 | [🔒 **Security**](SECURITY.md) | Security policy and responsible disclosure |
-| [📋 **Code of Conduct**](CODE_OF_CONDUCT.md) | Community guidelines |
 | [📋 **Code of Conduct**](CODE_OF_CONDUCT.md) | Community guidelines |
 
 ---
@@ -293,7 +313,7 @@ Forward-looking and shaped by the community — these are directions, not promis
 
 **🔜 Now**
 - [ ] Expand automated test coverage across views
-- [ ] Documented self-host / deployment guide
+- [x] Documented self-host / deployment guide
 - [ ] Deeper analytics on the dashboard
 
 **🛠️ Next**

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,120 @@
+# Self-Hosting SiteWise
+
+SiteWise has two deployable pieces:
+
+| Piece | What it is | Image / build |
+|---|---|---|
+| **Backend** | PocketBase (single Go binary, SQLite) bundled with SiteWise hooks | `external_services/pocketbase/Dockerfile` |
+| **Frontend** | Vue 3 SPA served by nginx | root `Dockerfile` |
+
+The frontend is a static bundle that talks to the backend over REST + realtime.
+The backend holds all of your data. You can host them on one box or two.
+
+---
+
+## 1. Backend (PocketBase)
+
+The backend is the source of truth — start here. Everything you need is in
+[`external_services/pocketbase/`](../external_services/pocketbase/), which has
+its own [README](../external_services/pocketbase/README.md) with the full
+matrix of environment variables.
+
+### Standard build
+
+```bash
+cd external_services/pocketbase
+TURNSTILE_SECRET_KEY=your-secret docker compose up -d --build
+```
+
+This builds an image on a pinned PocketBase release with the SiteWise hooks
+baked in, serves on port `8090`, and persists data in the `pb_data` volume.
+
+First-run setup:
+
+1. Open `http://YOUR_HOST:8090/_/` and create the first superuser.
+2. **Settings → Import collections** → paste/upload
+   [`pb_schema.json`](../external_services/pocketbase/pb_schema.json).
+3. (Optional) Set `TURNSTILE_SECRET_KEY` so the signup/login bot-protection
+   hooks can verify Cloudflare Turnstile tokens.
+
+> You can skip the manual superuser step by setting `PB_SUPERUSER_EMAIL` and
+> `PB_SUPERUSER_PASSWORD` — the entrypoint upserts the superuser on boot.
+
+### ONCE build
+
+If you deploy with the [ONCE](https://once.com/) app server (or any platform
+that expects the ONCE contract — HTTP on port `80`, readiness at `/up`, data in
+`/storage`), build the ONCE flavour instead:
+
+```bash
+docker build -f external_services/pocketbase/Dockerfile.once \
+  -t sitewise-backend-once external_services/pocketbase
+
+docker run -d --name sitewise-backend \
+  -p 80:80 -v sitewise_storage:/storage \
+  -e TURNSTILE_SECRET_KEY=your-secret \
+  sitewise-backend-once
+```
+
+---
+
+## 2. Frontend (Vue + nginx)
+
+The frontend reads `VITE_POCKETBASE_URL` **at build time** (Vite inlines env
+vars into the static bundle), so point it at your backend before building.
+
+```bash
+# from the repo root
+docker build \
+  --build-arg VITE_POCKETBASE_URL=https://api.your-domain.com \
+  -t sitewise-frontend .
+
+docker run -d --name sitewise-frontend -p 8080:8080 sitewise-frontend
+```
+
+Supported build args: `VITE_POCKETBASE_URL`, `VITE_APP_NAME`, `VITE_APP_ENV`,
+`VITE_TURNSTILE_SITE_KEY`. They default to development-friendly values, so
+**always** set at least `VITE_POCKETBASE_URL` when self-hosting.
+
+> The CSP in `nginx.conf` allow-lists the API origin in `connect-src` — update
+> it if your backend lives on a host other than the default `app.sitewise.in`.
+
+---
+
+## 3. Put a reverse proxy in front
+
+For anything internet-facing, terminate TLS at a reverse proxy (Caddy, nginx,
+Traefik) and route:
+
+- `https://your-domain.com` → frontend (`:8080`)
+- `https://api.your-domain.com` → backend (`:8090`)
+
+PocketBase docs recommend exposing the backend **only** through the proxy
+(don't publish `8090` directly). With ONCE, the platform provides the proxy and
+TLS for you — you only supply the image.
+
+---
+
+## Production checklist
+
+- [ ] Pin the PocketBase version (`--build-arg PB_VERSION=...`) and bump
+      deliberately.
+- [ ] Back up the data volume (`pb_data` / `/storage`) regularly — it holds the
+      SQLite DB **and** uploaded delivery photos.
+- [ ] Set a strong superuser password; never expose the `_/` admin UI without
+      TLS.
+- [ ] Provide `TURNSTILE_SECRET_KEY` in production so auth hooks enforce bot
+      protection.
+- [ ] Keep secrets out of the image — pass them as runtime env vars / Docker
+      secrets, never `COPY` an `.env` into the backend image.
+- [ ] Run the backend behind a reverse proxy with TLS; restrict direct access to
+      the PocketBase port.
+
+---
+
+## Why PocketBase is a good fit for self-hosting
+
+It's a single binary with embedded SQLite, so there's no separate database
+server to operate, and the entire backend — schema, files, settings — lives in
+one directory you can snapshot. That's also what makes the **ONCE** build so
+clean: one image, one volume, one port.

--- a/external_services/pocketbase/.dockerignore
+++ b/external_services/pocketbase/.dockerignore
@@ -1,0 +1,13 @@
+# Keep the backend build context tiny — only the hooks and entrypoint are
+# copied into the image. Everything below is documentation / local state.
+README.md
+pb_data/
+pb_data
+*.db
+*.db-shm
+*.db-wal
+*.log
+.DS_Store
+docker-compose.yml
+.env
+.env.*

--- a/external_services/pocketbase/Dockerfile
+++ b/external_services/pocketbase/Dockerfile
@@ -1,0 +1,106 @@
+# syntax=docker/dockerfile:1
+
+# =============================================================================
+# SiteWise PocketBase backend — standard production image
+# =============================================================================
+# Multi-stage, multi-arch build that bundles the SiteWise server-side hooks on
+# top of a pinned PocketBase release.
+#
+# Build (single arch):
+#   docker build -t sitewise-backend external_services/pocketbase
+#
+# Build a specific PocketBase version:
+#   docker build --build-arg PB_VERSION=0.39.4 -t sitewise-backend external_services/pocketbase
+#
+# Run:
+#   docker run -d --name sitewise-backend \
+#     -p 8090:8090 \
+#     -v sitewise_pb_data:/pb/pb_data \
+#     -e TURNSTILE_SECRET_KEY=your-secret \
+#     sitewise-backend
+# =============================================================================
+
+# Pin the PocketBase release. SiteWise hooks use the modern JSVM API
+# (onRecord*Success / e.app / e.next) and therefore require PocketBase >= 0.23.
+ARG PB_VERSION=0.39.4
+ARG ALPINE_VERSION=3.20
+
+# -----------------------------------------------------------------------------
+# Stage 1: download + verify the PocketBase binary for the target platform
+# -----------------------------------------------------------------------------
+FROM alpine:${ALPINE_VERSION} AS downloader
+
+ARG PB_VERSION
+# Provided automatically by BuildKit (e.g. linux/amd64, linux/arm64).
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN apk add --no-cache ca-certificates unzip wget
+
+WORKDIR /download
+
+# Map Docker's TARGETARCH to the naming used by PocketBase release assets.
+RUN set -eux; \
+    case "${TARGETARCH}${TARGETVARIANT}" in \
+      "amd64")  PB_ARCH="amd64"  ;; \
+      "arm64")  PB_ARCH="arm64"  ;; \
+      "armv7")  PB_ARCH="armv7"  ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}${TARGETVARIANT}" >&2; exit 1 ;; \
+    esac; \
+    PB_ZIP="pocketbase_${PB_VERSION}_${TARGETOS:-linux}_${PB_ARCH}.zip"; \
+    echo "Downloading ${PB_ZIP}"; \
+    wget -q "https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/${PB_ZIP}" -O pocketbase.zip; \
+    unzip pocketbase.zip pocketbase -d /download; \
+    chmod +x /download/pocketbase; \
+    /download/pocketbase --version
+
+# -----------------------------------------------------------------------------
+# Stage 2: minimal runtime image
+# -----------------------------------------------------------------------------
+FROM alpine:${ALPINE_VERSION} AS production
+
+ARG PB_VERSION
+
+# wget (busybox) is used by the HEALTHCHECK; ca-certificates/tzdata for TLS &
+# correct timezones in logs and scheduled jobs.
+RUN apk add --no-cache ca-certificates tzdata wget && \
+    addgroup -g 1001 -S pocketbase && \
+    adduser -S -u 1001 -G pocketbase pocketbase
+
+WORKDIR /pb
+
+COPY --from=downloader /download/pocketbase /usr/local/bin/pocketbase
+
+# Bundle the SiteWise server-side hooks and the entrypoint.
+COPY pb_hooks/ /pb/pb_hooks/
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh && \
+    mkdir -p /pb/pb_data /pb/pb_migrations /pb/pb_public && \
+    chown -R pocketbase:pocketbase /pb
+
+LABEL org.opencontainers.image.title="SiteWise Backend (PocketBase)" \
+      org.opencontainers.image.description="PocketBase backend for SiteWise, bundled with server-side hooks" \
+      org.opencontainers.image.vendor="SiteWise" \
+      org.opencontainers.image.source="https://github.com/site-wise/app" \
+      org.opencontainers.image.licenses="O'Saasy" \
+      io.sitewise.pocketbase.version="${PB_VERSION}"
+
+USER pocketbase
+
+# Persistent data (SQLite DB, uploaded files, settings) lives here.
+VOLUME ["/pb/pb_data"]
+
+ENV PB_HTTP=0.0.0.0:8090 \
+    PB_DATA_DIR=/pb/pb_data \
+    PB_HOOKS_DIR=/pb/pb_hooks \
+    PB_MIGRATIONS_DIR=/pb/pb_migrations \
+    PB_PUBLIC_DIR=/pb/pb_public
+
+EXPOSE 8090
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:8090/api/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/external_services/pocketbase/Dockerfile.once
+++ b/external_services/pocketbase/Dockerfile.once
@@ -1,0 +1,108 @@
+# syntax=docker/dockerfile:1
+
+# =============================================================================
+# SiteWise PocketBase backend — ONCE-compatible image
+# =============================================================================
+# Same backend as ./Dockerfile, packaged to satisfy the ONCE app server
+# contract (https://once.com / https://github.com/basecamp/once):
+#
+#   * Serves HTTP on port 80
+#   * Exposes a health/readiness endpoint at GET /up  (added via pb_hooks)
+#   * Keeps all persistent data under /storage
+#
+# This image runs as root so PocketBase can bind the privileged port 80
+# reliably under the ONCE runtime (which may apply no-new-privileges, stripping
+# file capabilities). The container is isolated by ONCE and holds no other
+# process; this mirrors how the reference ONCE apps (Campfire/Writebook) ship.
+# For an unprivileged, port-8090 deployment use the standard ./Dockerfile.
+#
+# Build:
+#   docker build -f external_services/pocketbase/Dockerfile.once \
+#     -t sitewise-backend-once external_services/pocketbase
+#
+# Run (mimicking ONCE):
+#   docker run -d --name sitewise-backend \
+#     -p 80:80 -v sitewise_storage:/storage \
+#     -e TURNSTILE_SECRET_KEY=your-secret \
+#     sitewise-backend-once
+# =============================================================================
+
+ARG PB_VERSION=0.39.4
+ARG ALPINE_VERSION=3.20
+
+# -----------------------------------------------------------------------------
+# Stage 1: download + verify the PocketBase binary for the target platform
+# -----------------------------------------------------------------------------
+FROM alpine:${ALPINE_VERSION} AS downloader
+
+ARG PB_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN apk add --no-cache ca-certificates unzip wget
+
+WORKDIR /download
+
+RUN set -eux; \
+    case "${TARGETARCH}${TARGETVARIANT}" in \
+      "amd64")  PB_ARCH="amd64"  ;; \
+      "arm64")  PB_ARCH="arm64"  ;; \
+      "armv7")  PB_ARCH="armv7"  ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}${TARGETVARIANT}" >&2; exit 1 ;; \
+    esac; \
+    PB_ZIP="pocketbase_${PB_VERSION}_${TARGETOS:-linux}_${PB_ARCH}.zip"; \
+    echo "Downloading ${PB_ZIP}"; \
+    wget -q "https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/${PB_ZIP}" -O pocketbase.zip; \
+    unzip pocketbase.zip pocketbase -d /download; \
+    chmod +x /download/pocketbase; \
+    /download/pocketbase --version
+
+# -----------------------------------------------------------------------------
+# Stage 2: minimal runtime image
+# -----------------------------------------------------------------------------
+FROM alpine:${ALPINE_VERSION} AS production
+
+ARG PB_VERSION
+
+# wget (busybox) is used by the HEALTHCHECK; ca-certificates/tzdata for TLS &
+# correct timezones in logs and scheduled jobs.
+RUN apk add --no-cache ca-certificates tzdata wget
+
+WORKDIR /pb
+
+COPY --from=downloader /download/pocketbase /usr/local/bin/pocketbase
+
+COPY pb_hooks/ /pb/pb_hooks/
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Create the ONCE storage layout. All mutable state is rooted at /storage so a
+# single mounted volume captures the entire backend.
+RUN chmod +x /usr/local/bin/entrypoint.sh && \
+    mkdir -p /storage/pb_data /pb/pb_migrations /pb/pb_public
+
+LABEL org.opencontainers.image.title="SiteWise Backend (PocketBase, ONCE)" \
+      org.opencontainers.image.description="ONCE-compatible PocketBase backend for SiteWise" \
+      org.opencontainers.image.vendor="SiteWise" \
+      org.opencontainers.image.source="https://github.com/site-wise/app" \
+      org.opencontainers.image.licenses="O'Saasy" \
+      io.sitewise.pocketbase.version="${PB_VERSION}"
+
+# Runs as root by design (see header) to bind privileged port 80 under ONCE.
+
+# The ONCE app server mounts a single persistent volume at /storage.
+VOLUME ["/storage"]
+
+ENV PB_HTTP=0.0.0.0:80 \
+    PB_DATA_DIR=/storage/pb_data \
+    PB_HOOKS_DIR=/pb/pb_hooks \
+    PB_MIGRATIONS_DIR=/pb/pb_migrations \
+    PB_PUBLIC_DIR=/pb/pb_public
+
+EXPOSE 80
+
+# ONCE probes /up; mirror that in the container healthcheck for consistency.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:80/up || exit 1
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/external_services/pocketbase/README.md
+++ b/external_services/pocketbase/README.md
@@ -7,6 +7,11 @@ This directory contains everything needed to set up PocketBase for the SiteWise 
 ```
 external_services/pocketbase/
 ├── README.md           # This file
+├── Dockerfile          # Standard production backend image
+├── Dockerfile.once     # ONCE-compatible image (port 80, /up, /storage)
+├── docker-compose.yml  # One-command local/prod backend
+├── entrypoint.sh       # Shared, env-driven container entrypoint
+├── .dockerignore       # Keeps the build context minimal
 ├── pb_schema.json      # Collection schema (import via Admin UI)
 └── pb_hooks/           # Server-side hooks (copy to PocketBase directory)
     ├── README.md       # Detailed hooks documentation
@@ -15,9 +20,85 @@ external_services/pocketbase/
     ├── process_invitations_on_acceptance.pb.js
     ├── create_user.pb.js
     ├── login.pb.js
+    ├── health.pb.js     # GET /up readiness endpoint
     ├── items.json       # Standard items seed data
     └── services.json    # Standard services seed data
 ```
+
+## Running with Docker (recommended)
+
+The hooks are bundled into a container image built on a pinned [PocketBase](https://pocketbase.io/)
+release. There are two flavours:
+
+| Image | Port | Data dir | Health | Use for |
+|---|---|---|---|---|
+| `Dockerfile` | `8090` | `/pb/pb_data` (volume) | `/api/health` | Normal self-hosting behind your own reverse proxy |
+| `Dockerfile.once` | `80` | `/storage` (volume) | `/up` | The [ONCE](https://once.com/) app server / any platform expecting the ONCE contract |
+
+### Quick start (Docker Compose)
+
+```bash
+cd external_services/pocketbase
+TURNSTILE_SECRET_KEY=your-secret docker compose up -d --build
+```
+
+Then open `http://localhost:8090/_/`, create the first superuser, and import
+`pb_schema.json` (**Settings → Import collections**). See [Setup
+Instructions](#setup-instructions) below.
+
+### Build & run manually
+
+```bash
+# Standard image (defaults to PocketBase 0.39.4 — override with --build-arg)
+docker build -t sitewise-backend external_services/pocketbase
+docker run -d --name sitewise-backend \
+  -p 8090:8090 \
+  -v sitewise_pb_data:/pb/pb_data \
+  -e TURNSTILE_SECRET_KEY=your-secret \
+  sitewise-backend
+```
+
+### Configuration
+
+The entrypoint is driven entirely by environment variables, so the same image
+works in plain Docker, Compose, Kubernetes, or ONCE:
+
+| Variable | Default (standard / ONCE) | Description |
+|---|---|---|
+| `TURNSTILE_SECRET_KEY` | — | **Required** by the signup/login hooks (Cloudflare Turnstile) |
+| `PB_HTTP` | `0.0.0.0:8090` / `0.0.0.0:80` | Bind address |
+| `PB_DATA_DIR` | `/pb/pb_data` / `/storage/pb_data` | Persistent data directory (mount a volume here) |
+| `PB_HOOKS_DIR` | `/pb/pb_hooks` | JS hooks directory |
+| `PB_MIGRATIONS_DIR` | `/pb/pb_migrations` | JS migrations directory |
+| `PB_PUBLIC_DIR` | `/pb/pb_public` | Static files directory |
+| `PB_ENCRYPTION_ENV` | — | Name of the env var holding the settings encryption key |
+| `PB_SUPERUSER_EMAIL` / `PB_SUPERUSER_PASSWORD` | — | Optional: create/update a superuser on startup (headless bootstrap) |
+
+> **Pinning the version** — both Dockerfiles default to a known-good PocketBase
+> release via `ARG PB_VERSION`. The hooks require the modern JSVM API
+> (PocketBase ≥ 0.23). Bump with `--build-arg PB_VERSION=x.y.z`.
+
+### ONCE-compatible build
+
+[ONCE](https://once.com/) (from 37signals) expects an image that serves HTTP on
+**port 80**, answers a readiness probe at **`/up`**, and stores all persistent
+data under **`/storage`**. `Dockerfile.once` satisfies all three — the `/up`
+route is added by `pb_hooks/health.pb.js`, and `PB_DATA_DIR` points at
+`/storage/pb_data` so a single mounted volume captures the whole backend.
+
+```bash
+docker build -f external_services/pocketbase/Dockerfile.once \
+  -t sitewise-backend-once external_services/pocketbase
+
+docker run -d --name sitewise-backend \
+  -p 80:80 \
+  -v sitewise_storage:/storage \
+  -e TURNSTILE_SECRET_KEY=your-secret \
+  sitewise-backend-once
+```
+
+See [docs/SELF_HOSTING.md](../../docs/SELF_HOSTING.md) for the full
+self-hosting walkthrough (frontend + backend together).
 
 ## Setup Instructions
 

--- a/external_services/pocketbase/docker-compose.yml
+++ b/external_services/pocketbase/docker-compose.yml
@@ -1,0 +1,36 @@
+# SiteWise PocketBase backend — standard (non-ONCE) deployment.
+#
+#   docker compose up -d --build
+#
+# Then open http://localhost:8090/_/ to create the first superuser and import
+# pb_schema.json (Settings > Import collections). See README.md for details.
+services:
+  pocketbase:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Bump to pull a newer PocketBase release (must be >= 0.23).
+        PB_VERSION: "0.39.4"
+    image: sitewise-backend:latest
+    container_name: sitewise-backend
+    restart: unless-stopped
+    ports:
+      - "8090:8090"
+    environment:
+      # Required by the signup/login hooks (Cloudflare Turnstile).
+      TURNSTILE_SECRET_KEY: "${TURNSTILE_SECRET_KEY:-1x0000000000000000000000000000000AA}"
+      # Optional: auto-create a superuser on first boot.
+      # PB_SUPERUSER_EMAIL: "admin@example.com"
+      # PB_SUPERUSER_PASSWORD: "change-me-please"
+    volumes:
+      - pb_data:/pb/pb_data
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8090/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  pb_data:

--- a/external_services/pocketbase/entrypoint.sh
+++ b/external_services/pocketbase/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Shared entrypoint for the SiteWise PocketBase backend image.
+#
+# Behaviour is controlled entirely through environment variables so the same
+# image/entrypoint serves both the standard build and the ONCE build:
+#
+#   PB_HTTP             Address PocketBase binds to        (default 0.0.0.0:8090)
+#   PB_DATA_DIR         Persistent data directory          (default /pb/pb_data)
+#   PB_HOOKS_DIR        JS hooks directory                 (default /pb/pb_hooks)
+#   PB_MIGRATIONS_DIR   JS migrations directory            (default /pb/pb_migrations)
+#   PB_PUBLIC_DIR       Static files directory             (default /pb/pb_public)
+#   PB_ENCRYPTION_ENV   Name of the env var holding the    (optional)
+#                       settings encryption key
+#   PB_SUPERUSER_EMAIL  Bootstrap a superuser on start     (optional)
+#   PB_SUPERUSER_PASSWORD                                  (optional)
+#
+# Any extra arguments passed to the container are forwarded to
+# `pocketbase serve` verbatim.
+set -eu
+
+PB_HTTP="${PB_HTTP:-0.0.0.0:8090}"
+PB_DATA_DIR="${PB_DATA_DIR:-/pb/pb_data}"
+PB_HOOKS_DIR="${PB_HOOKS_DIR:-/pb/pb_hooks}"
+PB_MIGRATIONS_DIR="${PB_MIGRATIONS_DIR:-/pb/pb_migrations}"
+PB_PUBLIC_DIR="${PB_PUBLIC_DIR:-/pb/pb_public}"
+
+# Ensure the persistent directory exists (it is usually a mounted volume).
+mkdir -p "$PB_DATA_DIR"
+
+set -- serve \
+  --http="$PB_HTTP" \
+  --dir="$PB_DATA_DIR" \
+  --hooksDir="$PB_HOOKS_DIR" \
+  --migrationsDir="$PB_MIGRATIONS_DIR" \
+  --publicDir="$PB_PUBLIC_DIR" \
+  "$@"
+
+if [ -n "${PB_ENCRYPTION_ENV:-}" ]; then
+  set -- "$@" --encryptionEnv="$PB_ENCRYPTION_ENV"
+fi
+
+# Optionally create/update a superuser before serving so the instance is
+# immediately usable in automated/headless deployments.
+if [ -n "${PB_SUPERUSER_EMAIL:-}" ] && [ -n "${PB_SUPERUSER_PASSWORD:-}" ]; then
+  echo "[entrypoint] Upserting superuser ${PB_SUPERUSER_EMAIL}"
+  pocketbase superuser upsert "$PB_SUPERUSER_EMAIL" "$PB_SUPERUSER_PASSWORD" \
+    --dir="$PB_DATA_DIR" || echo "[entrypoint] superuser upsert skipped/failed (continuing)"
+fi
+
+echo "[entrypoint] Starting PocketBase: pocketbase $*"
+exec pocketbase "$@"

--- a/external_services/pocketbase/pb_hooks/README.md
+++ b/external_services/pocketbase/pb_hooks/README.md
@@ -11,6 +11,7 @@ pb_hooks/
 ├── create_user.pb.js                           # Turnstile verification on signup
 ├── login.pb.js                                 # Turnstile verification on login
 ├── process_invitations_on_acceptance.pb.js     # Grants access on invitation accept
+├── health.pb.js                                # GET /up readiness endpoint
 ├── items.json                                  # Seed data: standard construction items
 └── services.json                               # Seed data: standard construction services
 ```
@@ -59,6 +60,14 @@ Utility functions used by other hooks via `require(`${__hooks}/utils.js`)`:
 - Validates Cloudflare Turnstile token from query params (`turnstileToken`)
 - Blocks login if token is missing or invalid
 - Requires `TURNSTILE_SECRET_KEY` environment variable
+
+### health.pb.js — Readiness Endpoint
+
+**`GET /up`:**
+- Unauthenticated route that returns `200 OK` (plain text)
+- Complements PocketBase's built-in `GET /api/health`
+- Matches the readiness-probe convention used by the [ONCE](https://once.com/)
+  app server and other orchestrators
 
 ### process_invitations_on_acceptance.pb.js — Invitation Handling
 

--- a/external_services/pocketbase/pb_hooks/health.pb.js
+++ b/external_services/pocketbase/pb_hooks/health.pb.js
@@ -1,0 +1,11 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Lightweight, unauthenticated liveness/readiness endpoint.
+//
+// PocketBase already exposes `GET /api/health`. This adds a plain-text
+// `GET /up` route that returns `200 OK`, matching the convention expected by
+// container orchestrators and self-hosting platforms — notably the ONCE app
+// server, which probes `/up` to decide when the app is ready to serve traffic.
+routerAdd("GET", "/up", (e) => {
+  return e.string(200, "OK")
+})


### PR DESCRIPTION
The backend previously had no container build — it was set up by hand (download the binary, import the schema, copy hooks). This adds a proper, reproducible Docker build for the PocketBase backend and a parallel ONCE-compatible image, plus hardens the existing frontend image.

Backend (external_services/pocketbase):
- Dockerfile: multi-stage, multi-arch (amd64/arm64/armv7) build on a pinned PocketBase release (ARG PB_VERSION, requires >= 0.23 for the JSVM hooks), non-root user, named-volume data dir, /api/health healthcheck, bundled SiteWise hooks.
- Dockerfile.once: ONCE app-server contract — serves on port 80, /up readiness probe, all state under /storage (single volume). Runs as root so it can bind :80 even when ONCE applies no-new-privileges.
- entrypoint.sh: shared, env-driven entrypoint (PB_HTTP/PB_DATA_DIR/hooks/ migrations/public, optional encryption env, optional headless superuser bootstrap).
- pb_hooks/health.pb.js: adds GET /up (200 OK) for the ONCE readiness probe.
- docker-compose.yml + .dockerignore for one-command local/prod runs.

Frontend (root Dockerfile):
- Fix broken build: install all deps in the builder (vite/vue-tsc are devDependencies, so `npm ci --only=production` could never build).
- Accept VITE_* build args (VITE_POCKETBASE_URL et al.) so self-hosters can point the bundle at their own backend instead of the baked-in localhost.

Docs:
- New docs/SELF_HOSTING.md (full backend + frontend + ONCE walkthrough).
- Backend README/hooks README documented; root README self-host section and docs index updated; roadmap self-host item checked off.

Image builds could not be exercised in the sandbox (egress policy blocks the Docker Hub blob CDN); validated via shell/JS syntax checks and compose config.


Claude-Session: https://claude.ai/code/session_01CjFTrATvPkAzwfPEbBTMfw

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test updates
- [ ] 🔒 Security fix
- [ ] 🎨 UI/UX improvement
- [ ] 🔨 Build/CI changes

## Related Issues

<!-- Link to related issues -->
Fixes #(issue_number)
Closes #(issue_number)
Related to #(issue_number)

## Changes Made

<!-- Detailed description of changes -->

### Frontend Changes
- [ ] Component updates
- [ ] New components added
- [ ] Styling changes
- [ ] Route changes
- [ ] State management updates

### Backend Changes
- [ ] API endpoints modified
- [ ] Database schema changes
- [ ] PocketBase collection updates
- [ ] Authentication changes
- [ ] Permission updates

### Other Changes
- [ ] Configuration updates
- [ ] Documentation updates
- [ ] Test updates
- [ ] Build process changes

## Testing

<!-- Describe the testing you've done -->

### Manual Testing
- [ ] Tested on desktop browser
- [ ] Tested on mobile browser
- [ ] Tested PWA functionality
- [ ] Tested with different user roles
- [ ] Tested edge cases

### Automated Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass (if applicable)
- [ ] Test coverage maintained/improved

### Test Environment
- **Browser(s)**: 
- **OS**: 
- **SiteWise Version**: 
- **PocketBase Version**: 

## Security Considerations

<!-- Address any security implications -->

- [ ] No sensitive data exposed
- [ ] Input validation implemented
- [ ] Authorization checks in place
- [ ] XSS prevention considered
- [ ] CSRF protection maintained
- [ ] No hardcoded secrets

## Performance Impact

<!-- Describe any performance implications -->

- [ ] No significant performance impact
- [ ] Performance improved
- [ ] Performance impact acceptable for new functionality
- [ ] Performance impact documented

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and how to migrate -->

### What breaks:

### Migration guide:

## Screenshots

<!-- Add screenshots for UI changes -->

### Before
<!-- Screenshot of old behavior -->

### After
<!-- Screenshot of new behavior -->

## Checklist

<!-- Verify these items before requesting review -->

### Code Quality
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is properly commented
- [ ] TypeScript types are properly defined
- [ ] No console.log statements left in code
- [ ] Error handling implemented

### Documentation
- [ ] Code documentation updated
- [ ] User documentation updated (if needed)
- [ ] README updated (if needed)
- [ ] CHANGELOG updated (if needed)

### Testing
- [ ] Tests added for new functionality
- [ ] All tests passing
- [ ] Test coverage adequate
- [ ] Manual testing completed

### Accessibility
- [ ] ARIA labels added where needed
- [ ] Keyboard navigation tested
- [ ] Color contrast verified
- [ ] Screen reader compatibility checked

### Mobile/PWA
- [ ] Mobile responsive design tested
- [ ] PWA functionality works
- [ ] Touch interactions work properly
- [ ] Offline functionality maintained

### Internationalization
- [ ] New text added to localization files
- [ ] Both English and Hindi translations provided
- [ ] No hardcoded text in components

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on -->

## Post-Merge Actions

<!-- Any actions needed after merging -->

- [ ] Deploy to staging
- [ ] Update production environment
- [ ] Database migrations needed
- [ ] Configuration updates required
- [ ] Announcement to team/users needed

---

**For Reviewers:**

- Review code quality and adherence to standards
- Test functionality manually if needed
- Verify security considerations
- Check accessibility compliance
- Ensure documentation is adequate