### PR TITLE
Add GHCR publishing for frontend and backend Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,88 @@
+name: Publish Docker images (GHCR)
+
+# Publishes the SiteWise container images to the GitHub Container Registry
+# (ghcr.io). Authentication uses the built-in GITHUB_TOKEN, so no registry
+# secrets need to be configured.
+#
+#   ghcr.io/site-wise/app          -> frontend (Vue 3 SPA on nginx, root Dockerfile)
+#   ghcr.io/site-wise/app-backend  -> backend (PocketBase + SiteWise hooks)
+#
+# Tagging:
+#   - push to main      -> :edge
+#   - push tag vX.Y.Z   -> :X.Y.Z, :X.Y, :latest
+#   - manual dispatch    -> :edge
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: frontend
+            image: app
+            context: .
+            dockerfile: Dockerfile
+          - name: backend
+            image: app-backend
+            context: external_services/pocketbase
+            dockerfile: external_services/pocketbase/Dockerfile
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # Lower-cased automatically; repo owner is "site-wise".
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=edge,enable={{is_default_branch}}
+          # Only tag :latest for stable version tags, never for branch pushes.
+          flavor: |
+            latest=auto
+
+      - name: Build and push ${{ matrix.name }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -12,6 +12,32 @@ The backend holds all of your data. You can host them on one box or two.
 
 ---
 
+## Prebuilt images (GHCR)
+
+Every release publishes both images to the GitHub Container Registry, so you can
+`docker pull` instead of building locally:
+
+| Image | Tags |
+|---|---|
+| `ghcr.io/site-wise/app` (frontend) | `latest`, `X.Y.Z`, `X.Y`, `edge` |
+| `ghcr.io/site-wise/app-backend` (PocketBase) | `latest`, `X.Y.Z`, `X.Y`, `edge` |
+
+`latest` tracks the most recent stable `vX.Y.Z` release; `edge` tracks `main`.
+Images are multi-arch (`linux/amd64`, `linux/arm64`).
+
+```bash
+docker pull ghcr.io/site-wise/app-backend:latest
+docker pull ghcr.io/site-wise/app:latest
+```
+
+> The **frontend** image bakes `VITE_POCKETBASE_URL` in at build time. The
+> published image uses the default (`http://localhost:8090`), so for a real
+> deployment you'll usually still build the frontend yourself with your backend
+> URL (see [§2](#2-frontend-vue--nginx)). The **backend** image is fully
+> configured at runtime, so the prebuilt one is ready to use as-is.
+
+---
+
 ## 1. Backend (PocketBase)
 
 The backend is the source of truth — start here. Everything you need is in


### PR DESCRIPTION
The repo had no GitHub Container Registry publishing: the only image
publish was the Docker Hub job in release.yml, which targets sitewise/app
on Docker Hub and builds the frontend only. The PocketBase backend images
added in #229 had no CI publishing at all.

Add .github/workflows/docker-publish.yml that publishes both images to
ghcr.io using the built-in GITHUB_TOKEN (no registry secrets required):

- ghcr.io/site-wise/app          -> frontend (root Dockerfile)
- ghcr.io/site-wise/app-backend  -> backend (external_services/pocketbase)

Built multi-arch (amd64/arm64) via a matrix, with per-image gha build
cache. Tagging: :edge on main, :X.Y.Z / :X.Y / :latest on v* tags.

Document the prebuilt images in docs/SELF_HOSTING.md, including the
caveat that the frontend bakes VITE_POCKETBASE_URL at build time so
self-hosters usually still build that image with their own backend URL.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RAn8Zj5LWwkb7sCmJPd8xV